### PR TITLE
Fixed viewport metaData tag to be comma-separated

### DIFF
--- a/CustomControls/unpHeader.xsp
+++ b/CustomControls/unpHeader.xsp
@@ -38,7 +38,7 @@ the specific language governing permissions and limitations under the License
 		<xp:script src="/unplugged.js" clientSide="true"></xp:script>
 		<xp:script src="/unpCommon.jss" clientSide="false"></xp:script>
 		<xp:metaData name="viewport"
-			content="width=device-width; user-scalable=yes; initial-scale=1; maximum-scale=1; minimum-scale=1">
+			content="width=device-width, user-scalable=yes, initial-scale=1, maximum-scale=1, minimum-scale=1">
 		</xp:metaData>
 	</xp:this.resources>
 


### PR DESCRIPTION
![ScreenShot035](https://f.cloud.github.com/assets/622118/291268/360c0662-9301-11e2-84bc-08aca17144fa.png)
Comma separation for mobile viewport metatag is required; semicolon is not a valid separator. Without, it gives itself as 2 errors and 2 warnings, seen in Chrome devtools.
